### PR TITLE
add missing word to signo disagreement note

### DIFF
--- a/lectures/L06-slides.tex
+++ b/lectures/L06-slides.tex
@@ -463,7 +463,7 @@
 
 	It contains the definitions that let you write \texttt{SIGKILL} instead of having to put an explicit int \texttt{9}.
 
-	Unfortunately there is not always 100\% agreement between different implementations about what the higher signal numbers.
+	Unfortunately there is not always 100\% agreement between different implementations about what the higher signal numbers mean.
 
 \end{frame}
 

--- a/lectures/L06-slides.tex
+++ b/lectures/L06-slides.tex
@@ -86,7 +86,7 @@
 
 	Synchronous Receive: the receiver is blocked until it receives a message.
 
-	Asynchronous Receive: the receiver continues execution and is notified when there is a message available.
+	Asynchronous Receive: the receiver is notified there is no message available and continues execution.
 
 \end{frame}
 

--- a/lectures/L06-slides.tex
+++ b/lectures/L06-slides.tex
@@ -86,7 +86,7 @@
 
 	Synchronous Receive: the receiver is blocked until it receives a message.
 
-	Asynchronous Receive: the receiver is notified there is no message available and continues execution.
+	Asynchronous Receive: the receiver continues execution and is notified when there is a message available.
 
 \end{frame}
 


### PR DESCRIPTION
The definition for *asynchronous receive* did not describe how messages are received.