### PR TITLE
Lecture 21 tex file fix

### DIFF
--- a/lectures/L21.tex
+++ b/lectures/L21.tex
@@ -205,7 +205,7 @@ type __sync_lock_test_and_set( type *ptr, type value );
 \end{lstlisting}
 
 
-The following functions are used to swap two values, only if the old value matches the expected (i.e., what was provided as the second argument):
+The following functions are used to swap two values, that is, if the current value of *ptr is oldval, then write newval into *ptr:
 
 \begin{lstlisting}[language=C]
 bool __sync_bool_compare_and_swap( type *ptr, type oldval, type newval );
@@ -282,4 +282,4 @@ There are further additional details related to use of spinlocks, which can of c
 
 \input{bibliography.tex}
 
-\end{document}
+\end{document} 

--- a/lectures/L21.tex
+++ b/lectures/L21.tex
@@ -282,4 +282,4 @@ There are further additional details related to use of spinlocks, which can of c
 
 \input{bibliography.tex}
 
-\end{document} 
+\end{document}


### PR DESCRIPTION
There is a logical bug in L21.tex where the description for __sync_bool_compare_and_swap does not match the description in the GNU documentation https://gcc.gnu.org/onlinedocs/gcc-4.1.1/gcc/Atomic-Builtins.html