### PR TITLE
FILE f -> FILE* f

### DIFF
--- a/lectures/L03-slides.tex
+++ b/lectures/L03-slides.tex
@@ -313,7 +313,7 @@ int result = flock( file_desc, LOCK_EX );
 	The first argument to this is the file pointer where you'd like the data to be written to:
 
 	\begin{lstlisting}[language=C]
-void write_points_to_file( point* p, FILE f ) {
+void write_points_to_file( point* p, FILE* f ) {
   while( p != NULL ) {
     fprintf(f, "(%d, %d, %d)\n", p->x, p->y, p->z);
     p = p->next;


### PR DESCRIPTION
The second parameter passed to the function is intended to be a file pointer but is missing the **"\*"**.